### PR TITLE
Fix: simplify_path sub not used correctly

### DIFF
--- a/change_properties.cgi
+++ b/change_properties.cgi
@@ -19,7 +19,7 @@ if(defined $in{'chmod'}) {
     if($in{'applyto'} eq '1') {
         foreach $name (split(/\0/, $in{'name'})) {
             $name =~ s/\.\.//g;
-            &simplify_path($name);
+            $name = &simplify_path($name);
             if (system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
@@ -30,7 +30,7 @@ if(defined $in{'chmod'}) {
     if($in{'applyto'} eq '2') {
         foreach $name (split(/\0/, $in{'name'})) {
             $name =~ s/\.\.//g;
-            &simplify_path($name);
+            $name = &simplify_path($name);
             if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
@@ -46,7 +46,7 @@ if(defined $in{'chmod'}) {
     if($in{'applyto'} eq '3') {
         foreach $name (split(/\0/, $in{'name'})) {
             $name =~ s/\.\.//g;
-            &simplify_path($name);
+            $name = &simplify_path($name);
             if(system_logged("chmod -R ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
@@ -57,7 +57,7 @@ if(defined $in{'chmod'}) {
     if($in{'applyto'} eq '4') {
         foreach $name (split(/\0/, $in{'name'})) {
             $name =~ s/\.\.//g;
-            &simplify_path($name);
+            $name = &simplify_path($name);
             if(-f "$cwd/$name") {
                 if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                     push @errors, "$name - $text{'error_chmod'}: $?";
@@ -74,7 +74,7 @@ if(defined $in{'chmod'}) {
     if($in{'applyto'} eq '5') {
         foreach $name (split(/\0/, $in{'name'})) {
             $name =~ s/\.\.//g;
-            &simplify_path($name);
+            $name = &simplify_path($name);
             if(-d "$cwd/$name") {
                 if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                     push @errors, "$name - $text{'error_chmod'}: $?";
@@ -107,7 +107,7 @@ if(defined $in{'chown'}) {
         if($in{'applyto'} eq '1') {
             foreach $name (split(/\0/, $in{'name'})) {
                 $name =~ s/\.\.//g;
-                &simplify_path($name);
+                $name = &simplify_path($name);
                 if(system_logged("chown $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
                     push @errors, "$name - $text{'error_chown'}: $?";
                 }
@@ -118,7 +118,7 @@ if(defined $in{'chown'}) {
         if($in{'applyto'} eq '2') {
             foreach $name (split(/\0/, $in{'name'})) {
                 $name =~ s/\.\.//g;
-                &simplify_path($name);
+                $name = &simplify_path($name);
                 if(system_logged("chown $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
                     push @errors, "$name - $text{'error_chown'}: $?";
                 }
@@ -134,7 +134,7 @@ if(defined $in{'chown'}) {
         if($in{'applyto'} eq '3') {
             foreach $name (split(/\0/, $in{'name'})) {
                 $name =~ s/\.\.//g;
-                &simplify_path($name);
+                $name = &simplify_path($name);
                 if(system_logged("chown -R $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
                     push @errors, "$name - $text{'error_chown'}: $?";
                 }
@@ -145,7 +145,7 @@ if(defined $in{'chown'}) {
         if($in{'applyto'} eq '4') {
             foreach $name (split(/\0/, $in{'name'})) {
                 $name =~ s/\.\.//g;
-                &simplify_path($name);
+                $name = &simplify_path($name);
                 if(-f "$cwd/$name") {
                     if(system_logged("chown $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
                         push @errors, "$name - $text{'error_chown'}: $?";
@@ -162,7 +162,7 @@ if(defined $in{'chown'}) {
         if($in{'applyto'} eq '5') {
             foreach $name (split(/\0/, $in{'name'})) {
                 $name =~ s/\.\.//g;
-                &simplify_path($name);
+                $name = &simplify_path($name);
                 if(-d "$cwd/$name") {
                     if(system_logged("chown $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
                         push @errors, "$name - $text{'error_chown'}: $?";

--- a/check_exists.cgi
+++ b/check_exists.cgi
@@ -11,7 +11,7 @@ print_ajax_header();
 
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
 
 #print '{"success": "1"}';
 

--- a/chmod.cgi
+++ b/chmod.cgi
@@ -19,8 +19,8 @@ my $permissions = oct_to_symbolic($permissions);
 if($in{'applyto'} eq '1') {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
-        if (system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
+        $name = &simplify_path($name);
+        if (!$name || system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
             push @errors, "$name - $text{'error_chmod'}: $?";
         }
     }
@@ -30,11 +30,11 @@ if($in{'applyto'} eq '1') {
 if($in{'applyto'} eq '2') {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
-        if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
+        $name = &simplify_path($name);
+        if(!$name || system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
             push @errors, "$name - $text{'error_chmod'}: $?";
         }
-        if(-d "$cwd/$name") {
+        if($name && -d "$cwd/$name") {
             if(system_logged("find ".quotemeta("$cwd/$name")." -maxdepth 1 -type f -exec chmod ".quotemeta($permissions)." {} \\;") != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
@@ -46,8 +46,8 @@ if($in{'applyto'} eq '2') {
 if($in{'applyto'} eq '3') {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
-        if(system_logged("chmod -R ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
+        $name = &simplify_path($name);
+        if(!$name || system_logged("chmod -R ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
             push @errors, "$name - $text{'error_chmod'}: $?";
         }
     }
@@ -57,13 +57,13 @@ if($in{'applyto'} eq '3') {
 if($in{'applyto'} eq '4') {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
-        if(-f "$cwd/$name") {
+        $name = &simplify_path($name);
+        if($name && -f "$cwd/$name") {
             if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
         } else {
-            if(system_logged("find ".quotemeta("$cwd/$name")." -type f -exec chmod ".quotemeta($permissions)." {} \\;") != 0) {
+            if(!$name || system_logged("find ".quotemeta("$cwd/$name")." -type f -exec chmod ".quotemeta($permissions)." {} \\;") != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }
         }
@@ -74,8 +74,8 @@ if($in{'applyto'} eq '4') {
 if($in{'applyto'} eq '5') {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
-        if(-d "$cwd/$name") {
+        $name = &simplify_path($name);
+        if($name && -d "$cwd/$name") {
             if(system_logged("chmod ".quotemeta($permissions)." ".quotemeta("$cwd/$name")) != 0) {
                 push @errors, "$name - $text{'error_chmod'}: $?";
             }

--- a/chown.cgi
+++ b/chown.cgi
@@ -33,7 +33,7 @@ if (scalar(@errors) > 0) {
 } else {
     foreach $name (split(/\0/, $in{'name'})) {
         $name =~ s/\.\.//g;
-        &simplify_path($name);
+        $name = &simplify_path($name);
         if(system_logged("chown $recursive $uid:$grid ".quotemeta("$cwd/$name")) != 0) {
             push @errors, "$name - $text{'error_chown'}: $?";
         }

--- a/compress.cgi
+++ b/compress.cgi
@@ -19,7 +19,7 @@ if(!$in{'archivename'} || ($in{'method'} ne 'tar' && $in{'method'} ne 'zip')) {
 # Remove exploiting "../" in new file names
 $archivename = $in{'archivename'};
 $archivename =~ s/\.\.//g;
-&simplify_path($archivename);
+$archivename = &simplify_path($archivename);
 
 my $command;
 
@@ -34,7 +34,7 @@ if($in{'method'} eq 'tar') {
 foreach my $name(split(/\0/, $in{'name'}))
 {
     $name =~ s/\.\.//g;
-    &simplify_path($name);
+    $name = &simplify_path($name) // next; # Missing/Invalid name - skip command
     $name =~ s/$in{'cwd'}\///ig;
     $command .= " ".quotemeta($name);
 }

--- a/create_file.cgi
+++ b/create_file.cgi
@@ -8,11 +8,11 @@ get_paths();
 # Remove exploiting "../" in new file names
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
 
 print_ajax_header();
 
-if(!$in{'name'}) {
+if(!$in{'name'} || !defined($name)) {
     print("{\"error\": \"$text{'provide_file_name'}\"}");
 } else {
     if (-e "$cwd/$name") {

--- a/create_folder.cgi
+++ b/create_folder.cgi
@@ -8,11 +8,11 @@ get_paths();
 # Remove exploiting "../" in new file names
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
 
 print_ajax_header();
 
-if(!$in{'name'}) {
+if(!$in{'name'} || !defined($name)) {
     print("{\"error\": \"$text{'provide_folder_name'}\"}");
 } else {
     if (-e "$cwd/$name") {

--- a/delete.cgi
+++ b/delete.cgi
@@ -12,8 +12,8 @@ print_ajax_header();
 
 foreach $name (split(/\0/, $in{'name[]'})) {
     $name =~ s/\.\.//g;
-    &simplify_path($name);
-    if(!&unlink_logged("$cwd/$name")) {
+    $name = &simplify_path($name);
+    if(!$name || !&unlink_logged("$cwd/$name")) {
         push @errors, "$name - $text{'error_delete'}: $!";
     }
 }

--- a/download_multi.cgi
+++ b/download_multi.cgi
@@ -16,7 +16,12 @@ if(!$in{'archivename'} || ($in{'method'} ne 'tar' && $in{'method'} ne 'zip')) {
 # Prevent exploiting "../"
 $archivename = $in{'archivename'};
 $archivename =~ s/\.\.//g;
-&simplify_path($archivename);
+$archivename = &simplify_path($archivename);
+
+if( !$archivename ){
+
+    print status('error', $text{'failed_to_read_file'});
+}
 
 my $command;
 
@@ -50,7 +55,7 @@ my $size = -s $tempfile;
 print "Content-Type: application/x-download\n";
 print "Content-Disposition: attachment; filename=\"$archivename\"\n";
 print "Content-Length: $size\n\n";
-open (FILE, "< $tempfile") or die "can't open $tempfile: $!";
+open (FILE, '<', $tempfile) or die "can't open $tempfile: $!";
 binmode FILE;
 local $/ = \102400;
 while (<FILE>) {

--- a/extract.cgi
+++ b/extract.cgi
@@ -15,7 +15,14 @@ if(!$in{'file'}) {
 # Remove exploiting "../"
 $file = $in{'file'};
 $file =~ s/\.\.//g;
-&simplify_path($file);
+$file = &simplify_path($file);
+
+if( !defined($file) ){
+
+	print_ajax_header();
+	print status('error', "$archive_type $text{'error_archive_type_not_supported'}");
+	exit;
+}
 
 print_ajax_header();
 

--- a/filemin-lib.pl
+++ b/filemin-lib.pl
@@ -311,7 +311,7 @@ sub status {
 sub sanitize {
 	my $param = @_[0];
 	$param =~ s/\.\.//g;
-	&simplify_path($param);
+	$param = &simplify_path($param);
 	return $param;
 }
 

--- a/get_file_contents.cgi
+++ b/get_file_contents.cgi
@@ -11,9 +11,9 @@ print_ajax_header();
 # Remove exploiting "../"
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name  = simplify_path($name);
 
-if(-e $cwd.'/'.$name) {
+if($name && -e $cwd.'/'.$name) {
     $data = &read_file_contents($cwd.'/'.$name);
     print $data;
 } else {

--- a/get_img.cgi
+++ b/get_img.cgi
@@ -11,7 +11,14 @@ get_paths();
 # Remove exploiting of "../" in file names
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
+
+if( !defined($name) ){
+
+	print_ajax_header();
+    print status('error', $text{'failed_to_read_file'});
+	exit;
+}
 
 my $img = $cwd.'/'.$name;
 my $size = -s "$img";

--- a/get_size.cgi
+++ b/get_size.cgi
@@ -15,13 +15,15 @@ $size = 0;
 foreach $name(@names) {
     # Remove exploiting of "../" in file parameters
     $name =~ s/\.\.//g;
-    &simplify_path($name);
+    $name = &simplify_path($name);
 
-    if(-d "$cwd/$name") {
+    if($name && -d "$cwd/$name") {
         $size = $size + &recursive_disk_usage("$cwd/$name");
-    } else {
+    } elsif( $name ) {
         my @fstat = stat "$cwd/$name";
         $size = $size + $fstat[7];
-    }
+    } else {
+		$size = undef;
+	}
 }
 print Mojo::JSON::to_json({'success' => 1, 'data' => $size});

--- a/list_archive.cgi
+++ b/list_archive.cgi
@@ -16,7 +16,7 @@ if(!$in{'file'}) {
 # Remove exploiting "../"
 $file = $in{'file'};
 $file =~ s/\.\.//g;
-&simplify_path($file);
+$file = &simplify_path($file);
 
 print_ajax_header();
 

--- a/rename.cgi
+++ b/rename.cgi
@@ -12,14 +12,14 @@ get_paths();
 # Remove exploiting "../" in new file names
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
 
 print_ajax_header();
 
-if (-e "$cwd/$name") {
+if ($name && -e "$cwd/$name") {
     print("{\"error\": \"<b>$name</b> $text{'error_exists'}\"}");
 } else {
-    if(&rename_file($cwd.'/'.$in{'file'}, $cwd.'/'.$name)) {
+    if($name && &rename_file($cwd.'/'.$in{'file'}, $cwd.'/'.$name)) {
         print '{"success": "1"}';
     } else {
         print("{\"error\": \"$text{'error_rename'} $in{'file'}: $!\"}");

--- a/save_file.cgi
+++ b/save_file.cgi
@@ -13,7 +13,7 @@ my @errors;
 # Remove exploiting of "../" in parameters
 $file = $in{'name'};
 $file =~ s/\.\.//g;
-&simplify_path($file);
+$file = &simplify_path($file);
 
 # Correct end of lines
 $data = $in{'data'};

--- a/update_symlink.cgi
+++ b/update_symlink.cgi
@@ -18,7 +18,7 @@ print_ajax_header();
 # Remove exploiting "../" in new file names
 $name = $in{'name'};
 $name =~ s/\.\.//g;
-&simplify_path($name);
+$name = &simplify_path($name);
 
 $link = $in{'link'};
 if(-e $link) {


### PR DESCRIPTION
This sub is from webmin. It doesn't work on reference, so to work it must get the return value.
Tested with webmin 1.790